### PR TITLE
Use released dep in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - git checkout v0.5
   - popd
   - go install github.com/gogo/protobuf/protoc-gen-gofast
-  - go get -u github.com/golang/dep/cmd/dep
+  - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
   - go get -u golang.org/x/tools/cmd/stringer
 
   - go generate


### PR DESCRIPTION
We need to use the released version of dep in travis, rather than chasing tip.

r? @aubrey-stripe 
(since we just went through this)