### PR TITLE
Remove deprecated restrict_network from stripe-build.yaml

### DIFF
--- a/stripe-build.yaml
+++ b/stripe-build.yaml
@@ -3,5 +3,4 @@
 henson_tarball:
   docker: {}
 network:
-  restrict_network: true
   http_proxy_report_only: true


### PR DESCRIPTION
This removes the deprecated `restrict_network` option from stripe-build.yaml. This option is
already a no-op so this PR should be a no-op. See http://go.corp.stripe.com/stripe-build-egress-restriction
for more information.

Self-lgtming this PR per discussion with @areitz that he will review one of these
autogenerated PRs and the generation code rather than each PR individually.

r? @andrew
cc @areitz
